### PR TITLE
[Add] Complete component struct implementation

### DIFF
--- a/cli/build.v
+++ b/cli/build.v
@@ -1,13 +1,12 @@
 module cli
 
 import os
-import x.json2
 import yaml
 import open_api
 
 pub fn build(path string, debug bool) ?string {
 	content := os.read_file(path) ?
 	raw_json := yaml.yaml_to_json(content, replace_tags: true, debug: int(debug)) ?
-	json_data := json2.decode<open_api.OpenApi>(raw_json) ?
+	json_data := open_api.decode<open_api.OpenApi>(raw_json) ?
 	return json_data.str()
 }

--- a/open_api/callback.v
+++ b/open_api/callback.v
@@ -1,14 +1,16 @@
 module open_api
 
-import x.json2 { Any, decode }
+import x.json2 { Any }
 import json
 
 type Callback = map[string]PathItem
 
-pub fn (mut callback Callback) from_json(json Any) {
+pub fn (mut callback Callback) from_json(json Any) ? {
 	mut tmp := map[string]PathItem{}
 	for key, value in json.as_map() {
-		tmp[key] = decode<PathItem>(value.json_str()) or { panic('Failed Callback decoding: $err') }
+		tmp[key] = decode<PathItem>(value.json_str()) or {
+			return error('Failed Callback decoding: $err')
+		}
 	}
 	callback = tmp
 }

--- a/open_api/components.v
+++ b/open_api/components.v
@@ -2,6 +2,7 @@ module open_api
 
 import x.json2 { Any }
 import json
+import regex
 
 struct Components {
 pub mut:
@@ -16,53 +17,53 @@ pub mut:
 	callbacks        map[string]ObjectRef<Callback>
 }
 
+fn check_key_regex(str string) bool {
+	mut reg := regex.regex_opt(r'^[\w\.\-]+$') or { panic('Failed to initialize regex expression') }
+	return reg.matches_string(str)
+}
+
 pub fn (mut components Components) from_json(json Any) {
 	for key, value in json.as_map() {
 		match key {
 			'SecuritySchemes' {
-				components.security_schemes = decode_map_sumtype<SecurityScheme>(value.json_str()) or {
-					panic('Failed Components decoding: $err')
-				}
+				components.security_schemes = decode_map_sumtype<SecurityScheme>(value.json_str(),
+					check_key_regex) or { panic('Failed Components decoding: $err') }
 			}
 			'requestBodies' {
-				components.request_bodies = decode_map_sumtype<RequestBody>(value.json_str()) or {
-					panic('Failed Components decoding: $err')
-				}
+				components.request_bodies = decode_map_sumtype<RequestBody>(value.json_str(),
+					check_key_regex) or { panic('Failed Components decoding: $err') }
 			}
 			'schemas' {
-				components.schemas = decode_map_sumtype<Schema>(value.json_str()) or {
+				components.schemas = decode_map_sumtype<Schema>(value.json_str(), check_key_regex) or {
 					panic('Failed Components decoding: $err')
 				}
 			}
 			'responses' {
-				components.responses = decode_map_sumtype<Response>(value.json_str()) or {
-					panic('Failed Components decoding: $err')
-				}
+				components.responses = decode_map_sumtype<Response>(value.json_str(),
+					check_key_regex) or { panic('Failed Components decoding: $err') }
 			}
 			'parameters' {
-				components.parameters = decode_map_sumtype<Parameter>(value.json_str()) or {
-					panic('Failed Components decoding: $err')
-				}
+				components.parameters = decode_map_sumtype<Parameter>(value.json_str(),
+					check_key_regex) or { panic('Failed Components decoding: $err') }
 			}
 			'examples' {
-				components.examples = decode_map_sumtype<Example>(value.json_str()) or {
+				components.examples = decode_map_sumtype<Example>(value.json_str(), check_key_regex) or {
 					panic('Failed Components decoding: $err')
 				}
 			}
 			'headers' {
-				components.headers = decode_map_sumtype<Header>(value.json_str()) or {
+				components.headers = decode_map_sumtype<Header>(value.json_str(), check_key_regex) or {
 					panic('Failed Components decoding: $err')
 				}
 			}
 			'links' {
-				components.links = decode_map_sumtype<Link>(value.json_str()) or {
+				components.links = decode_map_sumtype<Link>(value.json_str(), check_key_regex) or {
 					panic('Failed Components decoding: $err')
 				}
 			}
 			'callbacks' {
-				components.callbacks = decode_map_sumtype<Callback>(value.json_str()) or {
-					panic('Failed Components decoding: $err')
-				}
+				components.callbacks = decode_map_sumtype<Callback>(value.json_str(),
+					check_key_regex) or { panic('Failed Components decoding: $err') }
 			}
 			else {}
 		}

--- a/open_api/components.v
+++ b/open_api/components.v
@@ -22,48 +22,48 @@ fn check_key_regex(str string) bool {
 	return reg.matches_string(str)
 }
 
-pub fn (mut components Components) from_json(json Any) {
+pub fn (mut components Components) from_json(json Any) ? {
 	for key, value in json.as_map() {
 		match key {
-			'SecuritySchemes' {
+			'securitySchemes' {
 				components.security_schemes = decode_map_sumtype<SecurityScheme>(value.json_str(),
-					check_key_regex) or { panic('Failed Components decoding: $err') }
+					check_key_regex) or { return error('Failed Components decoding: $err') }
 			}
 			'requestBodies' {
 				components.request_bodies = decode_map_sumtype<RequestBody>(value.json_str(),
-					check_key_regex) or { panic('Failed Components decoding: $err') }
+					check_key_regex) or { return error('Failed Components decoding: $err') }
 			}
 			'schemas' {
 				components.schemas = decode_map_sumtype<Schema>(value.json_str(), check_key_regex) or {
-					panic('Failed Components decoding: $err')
+					return error('Failed Components decoding: $err')
 				}
 			}
 			'responses' {
 				components.responses = decode_map_sumtype<Response>(value.json_str(),
-					check_key_regex) or { panic('Failed Components decoding: $err') }
+					check_key_regex) or { return error('Failed Components decoding: $err') }
 			}
 			'parameters' {
 				components.parameters = decode_map_sumtype<Parameter>(value.json_str(),
-					check_key_regex) or { panic('Failed Components decoding: $err') }
+					check_key_regex) or { return error('Failed Components decoding: $err') }
 			}
 			'examples' {
 				components.examples = decode_map_sumtype<Example>(value.json_str(), check_key_regex) or {
-					panic('Failed Components decoding: $err')
+					return error('Failed Components decoding: $err')
 				}
 			}
 			'headers' {
 				components.headers = decode_map_sumtype<Header>(value.json_str(), check_key_regex) or {
-					panic('Failed Components decoding: $err')
+					return error('Failed Components decoding: $err')
 				}
 			}
 			'links' {
 				components.links = decode_map_sumtype<Link>(value.json_str(), check_key_regex) or {
-					panic('Failed Components decoding: $err')
+					return error('Failed Components decoding: $err')
 				}
 			}
 			'callbacks' {
 				components.callbacks = decode_map_sumtype<Callback>(value.json_str(),
-					check_key_regex) or { panic('Failed Components decoding: $err') }
+					check_key_regex) or { return error('Failed Components decoding: $err') }
 			}
 			else {}
 		}

--- a/open_api/encoding.v
+++ b/open_api/encoding.v
@@ -12,7 +12,7 @@ pub mut:
 	explode        bool
 }
 
-pub fn (mut encoding Encoding) from_json(json Any) {
+pub fn (mut encoding Encoding) from_json(json Any) ? {
 	for key, value in json.as_map() {
 		match key {
 			'contentType' {
@@ -23,7 +23,7 @@ pub fn (mut encoding Encoding) from_json(json Any) {
 			}
 			'headers' {
 				encoding.headers = decode_map_sumtype<Header>(value.json_str(), fake_predicat) or {
-					panic('Failed "Encoding" decoding: $err')
+					return error('Failed "Encoding" decoding: $err')
 				}
 			}
 			'style' {

--- a/open_api/encoding.v
+++ b/open_api/encoding.v
@@ -22,7 +22,7 @@ pub fn (mut encoding Encoding) from_json(json Any) {
 				encoding.allow_reserved = value.bool()
 			}
 			'headers' {
-				encoding.headers = decode_map_sumtype<Header>(value.json_str()) or {
+				encoding.headers = decode_map_sumtype<Header>(value.json_str(), fake_predicat) or {
 					panic('Failed "Encoding" decoding: $err')
 				}
 			}

--- a/open_api/example.v
+++ b/open_api/example.v
@@ -11,7 +11,7 @@ pub mut:
 	value          Any
 }
 
-pub fn (mut example Example) from_json(json Any) {
+pub fn (mut example Example) from_json(json Any) ? {
 	for key, value in json.as_map() {
 		match key {
 			'externalValue' {

--- a/open_api/header.v
+++ b/open_api/header.v
@@ -11,9 +11,9 @@ pub mut:
 	deprecated        bool
 }
 
-pub fn (mut header Header) from_json(json Any) {
+pub fn (mut header Header) from_json(json Any) ? {
 	object := json.as_map()
-	check_required<Header>(object, 'required')
+	check_required<Header>(object, 'required') ?
 
 	for key, value in object {
 		match key {

--- a/open_api/helpers.v
+++ b/open_api/helpers.v
@@ -53,7 +53,11 @@ pub fn decode_map_any(src string) ?map[string]Any {
 	return typ
 }
 
-pub fn decode_map_sumtype<T>(src string) ?map[string]ObjectRef<T> {
+fn fake_predicat(str string) bool {
+	return true
+}
+
+pub fn decode_map_sumtype<T>(src string, verif fn (string) bool) ?map[string]ObjectRef<T> {
 	json := raw_decode(src) ?
 	mut typ := map[string]ObjectRef<T>{}
 

--- a/open_api/info.v
+++ b/open_api/info.v
@@ -1,6 +1,6 @@
 module open_api
 
-import x.json2 { Any, decode }
+import x.json2 { Any }
 import json
 
 struct Info {
@@ -13,9 +13,9 @@ pub mut:
 	license          License
 }
 
-pub fn (mut info Info) from_json(json Any) {
+pub fn (mut info Info) from_json(json Any) ? {
 	object := json.as_map()
-	check_required<Info>(object, 'title', 'version')
+	check_required<Info>(object, 'title', 'version') ?
 
 	for key, value in object {
 		match key {
@@ -33,12 +33,12 @@ pub fn (mut info Info) from_json(json Any) {
 			}
 			'contact' {
 				info.contact = decode<Contact>(value.json_str()) or {
-					panic('Failed Info decoding: $err')
+					return error('Failed Info decoding: $err')
 				}
 			}
 			'license' {
 				info.license = decode<License>(value.json_str()) or {
-					panic('Failed Info decoding: $err')
+					return error('Failed Info decoding: $err')
 				}
 			}
 			else {}
@@ -55,7 +55,7 @@ pub mut:
 	email string
 }
 
-pub fn (mut contact Contact) from_json(json Any) {
+pub fn (mut contact Contact) from_json(json Any) ? {
 	object := json.as_map()
 	for key, value in object {
 		match key {
@@ -75,9 +75,9 @@ pub mut:
 	url  string
 }
 
-pub fn (mut license License) from_json(json Any) {
+pub fn (mut license License) from_json(json Any) ? {
 	object := json.as_map()
-	check_required<License>(object, 'name')
+	check_required<License>(object, 'name') ?
 
 	for key, value in object {
 		match key {

--- a/open_api/link.v
+++ b/open_api/link.v
@@ -1,6 +1,6 @@
 module open_api
 
-import x.json2 { Any, decode }
+import x.json2 { Any }
 import json
 
 struct Link {
@@ -13,7 +13,7 @@ pub mut:
 	server        Server
 }
 
-pub fn (mut link Link) from_json(json Any) {
+pub fn (mut link Link) from_json(json Any) ? {
 	for key, value in json.as_map() {
 		match key {
 			'operationRef' {
@@ -27,7 +27,7 @@ pub fn (mut link Link) from_json(json Any) {
 			}
 			'parameters' {
 				link.parameters = decode_map_any(value.json_str()) or {
-					panic('Failed Link decoding: $err')
+					return error('Failed Link decoding: $err')
 				}
 			}
 			'description' {
@@ -35,7 +35,7 @@ pub fn (mut link Link) from_json(json Any) {
 			}
 			'server' {
 				link.server = decode<Server>(value.json_str()) or {
-					panic('Failed Link decoding: $err')
+					return error('Failed Link decoding: $err')
 				}
 			}
 			else {}

--- a/open_api/openapi.v
+++ b/open_api/openapi.v
@@ -1,6 +1,6 @@
 module open_api
 
-import x.json2 { Any, decode }
+import x.json2 { Any }
 import json
 
 struct OpenApi {
@@ -15,9 +15,9 @@ pub mut:
 	tags          []Tag
 }
 
-pub fn (mut open_api OpenApi) from_json(json Any) {
+pub fn (mut open_api OpenApi) from_json(json Any) ? {
 	object := json.as_map()
-	check_required<OpenApi>(object, 'openapi', 'info', 'paths')
+	check_required<OpenApi>(object, 'openapi', 'info', 'paths') ?
 
 	for key, value in object {
 		match key {
@@ -26,37 +26,37 @@ pub fn (mut open_api OpenApi) from_json(json Any) {
 			}
 			'info' {
 				open_api.info = decode<Info>(value.json_str()) or {
-					panic('Failed OpenApi decoding: $err')
+					return error('Failed OpenApi decoding: $err')
 				}
 			}
 			'paths' {
 				open_api.paths = decode<map[string]PathItem>(value.json_str()) or {
-					panic('Failed OpenApi decoding: $err')
+					return error('Failed OpenApi decoding: $err')
 				}
 			}
 			'externalDocs' {
 				open_api.external_docs = decode<ExternalDocumentation>(value.json_str()) or {
-					panic('Failed OpenApi decoding: $err')
+					return error('Failed OpenApi decoding: $err')
 				}
 			}
 			'servers' {
 				open_api.servers = decode_array<Server>(value.json_str()) or {
-					panic('Failed OpenApi decoding: $err')
+					return error('Failed OpenApi decoding: $err')
 				}
 			}
 			'components' {
 				open_api.components = decode<Components>(value.json_str()) or {
-					panic('Failed OpenApi decoding: $err')
+					return error('Failed OpenApi decoding: $err')
 				}
 			}
 			'security' {
 				open_api.security = decode_array<SecurityRequirement>(value.json_str()) or {
-					panic('Failed OpenApi decoding: $err')
+					return error('Failed OpenApi decoding: $err')
 				}
 			}
 			'tags' {
 				open_api.tags = decode_array<Tag>(value.json_str()) or {
-					panic('Failed OpenApi decoding: $err')
+					return error('Failed OpenApi decoding: $err')
 				}
 			}
 			else {}
@@ -70,5 +70,5 @@ struct Schema {
 	// Todo: flemme
 }
 
-pub fn (mut schema Schema) from_json(json Any) {
+pub fn (mut schema Schema) from_json(json Any) ? {
 }

--- a/open_api/operation.v
+++ b/open_api/operation.v
@@ -1,6 +1,6 @@
 module open_api
 
-import x.json2 { Any, decode }
+import x.json2 { Any }
 import json
 
 struct Operation {
@@ -19,26 +19,26 @@ pub mut:
 	servers       []Server
 }
 
-pub fn (mut operation Operation) from_json(json Any) {
+pub fn (mut operation Operation) from_json(json Any) ? {
 	object := json.as_map()
-	check_required<Operation>(object, 'responses')
+	check_required<Operation>(object, 'responses') ?
 
 	for key, value in json.as_map() {
 		match key {
 			'externalDocs' {
 				operation.external_docs = decode<ExternalDocumentation>(value.json_str()) or {
-					panic('Failed Operation decoding: $err')
+					return error('Failed Operation decoding: $err')
 				}
 			}
 			'operationId' {
 				operation.operation_id = value.str()
 			}
 			'request_body' {
-				operation.request_body = from_json<RequestBody>(value)
+				operation.request_body = from_json<RequestBody>(value) ?
 			}
 			'tags' {
 				operation.tags = decode_array_string(value.json_str()) or {
-					panic('Failed Operation decoding: $err')
+					return error('Failed Operation decoding: $err')
 				}
 			}
 			'summary' {
@@ -49,17 +49,17 @@ pub fn (mut operation Operation) from_json(json Any) {
 			}
 			'parameters' {
 				operation.parameters = decode<[]ObjectRef<Parameter>>(value.json_str()) or {
-					panic('Failed Operation decoding: $err')
+					return error('Failed Operation decoding: $err')
 				}
 			}
 			'responses' {
 				operation.responses = decode<Responses>(value.json_str()) or {
-					panic('Failed Operation decoding: $err')
+					return error('Failed Operation decoding: $err')
 				}
 			}
 			'callbacks' {
 				operation.callbacks = decode_map_sumtype<Callback>(value.json_str(), fake_predicat) or {
-					panic('Failed Operation decoding: $err')
+					return error('Failed Operation decoding: $err')
 				}
 			}
 			'deprecated' {
@@ -67,12 +67,12 @@ pub fn (mut operation Operation) from_json(json Any) {
 			}
 			'security' {
 				operation.security = decode_array<SecurityRequirement>(value.json_str()) or {
-					panic('Failed Operation decoding: $err')
+					return error('Failed Operation decoding: $err')
 				}
 			}
 			'servers' {
 				operation.servers = decode_array<Server>(value.json_str()) or {
-					panic('Failed Operation decoding: $err')
+					return error('Failed Operation decoding: $err')
 				}
 			}
 			else {}
@@ -86,9 +86,9 @@ pub mut:
 	url         string
 }
 
-pub fn (mut external_doc ExternalDocumentation) from_json(json Any) {
+pub fn (mut external_doc ExternalDocumentation) from_json(json Any) ? {
 	object := json.as_map()
-	check_required<ExternalDocumentation>(object, 'url')
+	check_required<ExternalDocumentation>(object, 'url') ?
 
 	for key, value in object {
 		match key {

--- a/open_api/operation.v
+++ b/open_api/operation.v
@@ -58,7 +58,7 @@ pub fn (mut operation Operation) from_json(json Any) {
 				}
 			}
 			'callbacks' {
-				operation.callbacks = decode_map_sumtype<Callback>(value.json_str()) or {
+				operation.callbacks = decode_map_sumtype<Callback>(value.json_str(), fake_predicat) or {
 					panic('Failed Operation decoding: $err')
 				}
 			}

--- a/open_api/parameter.v
+++ b/open_api/parameter.v
@@ -13,9 +13,9 @@ pub mut: // Todo: To be completed
 	deprecated        bool
 }
 
-pub fn (mut parameter Parameter) from_json(json Any) {
+pub fn (mut parameter Parameter) from_json(json Any) ? {
 	object := json.as_map()
-	check_required<Parameter>(object, 'in', 'name', 'required')
+	check_required<Parameter>(object, 'in', 'name', 'required') ?
 
 	for key, value in json.as_map() {
 		match key {

--- a/open_api/path_item.v
+++ b/open_api/path_item.v
@@ -1,6 +1,6 @@
 module open_api
 
-import x.json2 { Any, decode }
+import x.json2 { Any }
 import json
 
 struct PathItem {
@@ -32,7 +32,7 @@ pub fn clean_path_expression(path string) string {
 	return path_copy
 }
 
-pub fn (mut path_item PathItem) from_json(json Any) {
+pub fn (mut path_item PathItem) from_json(json Any) ? {
 	for key, value in json.as_map() {
 		match key {
 			'\$ref' {
@@ -46,52 +46,52 @@ pub fn (mut path_item PathItem) from_json(json Any) {
 			}
 			'get' {
 				path_item.get = decode<Operation>(value.json_str()) or {
-					panic('Failed PathItem decoding: $err')
+					return error('Failed PathItem decoding: $err')
 				}
 			}
 			'put' {
 				path_item.put = decode<Operation>(value.json_str()) or {
-					panic('Failed PathItem decoding: $err')
+					return error('Failed PathItem decoding: $err')
 				}
 			}
 			'post' {
 				path_item.post = decode<Operation>(value.json_str()) or {
-					panic('Failed PathItem decoding: $err')
+					return error('Failed PathItem decoding: $err')
 				}
 			}
 			'delete' {
 				path_item.delete = decode<Operation>(value.json_str()) or {
-					panic('Failed PathItem decoding: $err')
+					return error('Failed PathItem decoding: $err')
 				}
 			}
 			'options' {
 				path_item.options = decode<Operation>(value.json_str()) or {
-					panic('Failed PathItem decoding: $err')
+					return error('Failed PathItem decoding: $err')
 				}
 			}
 			'head' {
 				path_item.head = decode<Operation>(value.json_str()) or {
-					panic('Failed PathItem decoding: $err')
+					return error('Failed PathItem decoding: $err')
 				}
 			}
 			'patch' {
 				path_item.patch = decode<Operation>(value.json_str()) or {
-					panic('Failed PathItem decoding: $err')
+					return error('Failed PathItem decoding: $err')
 				}
 			}
 			'trace' {
 				path_item.trace = decode<Operation>(value.json_str()) or {
-					panic('Failed PathItem decoding: $err')
+					return error('Failed PathItem decoding: $err')
 				}
 			}
 			'servers' {
 				path_item.servers = decode_array<Server>(value.json_str()) or {
-					panic('Failed PathItem decoding: $err')
+					return error('Failed PathItem decoding: $err')
 				}
 			}
 			'parameters' {
 				path_item.parameters = decode<[]ObjectRef<Parameter>>(value.json_str()) or {
-					panic('Failed PathItem decoding: $err')
+					return error('Failed PathItem decoding: $err')
 				}
 			}
 			else {}
@@ -99,10 +99,10 @@ pub fn (mut path_item PathItem) from_json(json Any) {
 	}
 }
 
-pub fn (mut paths map[string]PathItem) from_json(json Any) {
+pub fn (mut paths map[string]PathItem) from_json(json Any) ? {
 	for key, value in json.as_map() {
 		if !key.starts_with('/') {
-			panic('Failed map[string]PathItem decoding: path do not start with "/" !')
+			return error('Failed map[string]PathItem decoding: path do not start with "/" !')
 		}
 
 		for path in paths.keys() {
@@ -110,12 +110,12 @@ pub fn (mut paths map[string]PathItem) from_json(json Any) {
 			cleaned_k := clean_path_expression(key)
 
 			if cleaned_path == cleaned_k {
-				panic('Failed map[string]PathItem decoding: Identical path found !')
+				return error('Failed map[string]PathItem decoding: Identical path found !')
 			}
 		}
 
 		paths[key] = decode<PathItem>(value.json_str()) or {
-			panic('Failed map[string]PathItem decoding: $err')
+			return error('Failed map[string]PathItem decoding: $err')
 		}
 	}
 }

--- a/open_api/reference.v
+++ b/open_api/reference.v
@@ -1,6 +1,6 @@
 module open_api
 
-import x.json2 { Any, decode, raw_decode }
+import x.json2 { Any, raw_decode }
 import json
 
 struct Reference {
@@ -8,9 +8,9 @@ pub mut:
 	ref string
 }
 
-pub fn (mut reference Reference) from_json(json Any) {
+pub fn (mut reference Reference) from_json(json Any) ? {
 	object := json.as_map()
-	check_required<Reference>(object, '\$ref')
+	check_required<Reference>(object, '\$ref') ?
 
 	for key, value in object {
 		match key {
@@ -26,18 +26,18 @@ pub fn (mut reference Reference) from_json(json Any) {
 
 type ObjectRef<T> = Reference | T
 
-pub fn from_json<T>(json Any) ObjectRef<T> {
+pub fn from_json<T>(json Any) ?ObjectRef<T> {
 	if tmp := decode<T>(json.json_str()) {
 		return tmp
 	}
-	return decode<Reference>(json.json_str()) or { panic('') }
+	return decode<Reference>(json.json_str()) or { return error('') }
 }
 
 // ---------------------------------------- //
 
-pub fn (mut object []ObjectRef<Parameter>) from_json(json Any) {
+pub fn (mut object []ObjectRef<Parameter>) from_json(json Any) ? {
 	for value in json.arr() {
-		str := raw_decode(value.json_str()) or { panic('') }
-		object << from_json<Parameter>(str)
+		str := raw_decode(value.json_str()) or { return error('') }
+		object << from_json<Parameter>(str) ?
 	}
 }

--- a/open_api/request_body.v
+++ b/open_api/request_body.v
@@ -55,7 +55,7 @@ pub fn (mut media_type MediaType) from_json(json Any) {
 				media_type.example = value
 			}
 			'examples' {
-				media_type.examples = decode_map_sumtype<Example>(value.json_str()) or {
+				media_type.examples = decode_map_sumtype<Example>(value.json_str(), fake_predicat) or {
 					panic('Failed MediaType decoding: $err')
 				}
 			}

--- a/open_api/request_body.v
+++ b/open_api/request_body.v
@@ -10,9 +10,9 @@ pub mut:
 	required    bool
 }
 
-pub fn (mut request_body RequestBody) from_json(json Any) {
+pub fn (mut request_body RequestBody) from_json(json Any) ? {
 	object := json.as_map()
-	check_required<RequestBody>(object, 'content')
+	check_required<RequestBody>(object, 'content') ?
 
 	for key, value in object {
 		match key {
@@ -21,7 +21,7 @@ pub fn (mut request_body RequestBody) from_json(json Any) {
 			}
 			'content' {
 				request_body.content = decode_map<MediaType>(value.json_str()) or {
-					panic('Failed RequestBody decoding: $err')
+					return error('Failed RequestBody decoding: $err')
 				}
 			}
 			'required' {
@@ -42,26 +42,23 @@ pub mut:
 	encoding map[string]Encoding
 }
 
-pub fn (mut media_type MediaType) from_json(json Any) {
-	object := json.as_map()
-	check_required<MediaType>(object, 'content')
-
-	for key, value in object {
+pub fn (mut media_type MediaType) from_json(json Any) ? {
+	for key, value in json.as_map() {
 		match key {
 			'schema' {
-				media_type.schema = from_json<Schema>(value.json_str())
+				media_type.schema = from_json<Schema>(value.json_str()) ?
 			}
 			'example' {
 				media_type.example = value
 			}
 			'examples' {
 				media_type.examples = decode_map_sumtype<Example>(value.json_str(), fake_predicat) or {
-					panic('Failed MediaType decoding: $err')
+					return error('Failed MediaType decoding: $err')
 				}
 			}
 			'encoding' {
 				media_type.encoding = decode_map<Encoding>(value.json_str()) or {
-					panic('Failed MediaType decoding: $err')
+					return error('Failed MediaType decoding: $err')
 				}
 			}
 			else {}

--- a/open_api/responses.v
+++ b/open_api/responses.v
@@ -41,7 +41,7 @@ pub fn (mut response Response) from_json(json Any) {
 				response.description = value.str()
 			}
 			'headers' {
-				response.headers = decode_map_sumtype<Header>(value.json_str()) or {
+				response.headers = decode_map_sumtype<Header>(value.json_str(), fake_predicat) or {
 					panic('Failed Response decoding: $err')
 				}
 			}
@@ -51,7 +51,7 @@ pub fn (mut response Response) from_json(json Any) {
 				}
 			}
 			'links' {
-				response.links = decode_map_sumtype<Link>(value.json_str()) or {
+				response.links = decode_map_sumtype<Link>(value.json_str(), fake_predicat) or {
 					panic('Failed Response decoding: $err')
 				}
 			}

--- a/open_api/responses.v
+++ b/open_api/responses.v
@@ -9,11 +9,11 @@ pub mut:
 	http_status_code ObjectRef<Response> // Todo: find a way to do integer matching
 }
 
-pub fn (mut responses Responses) from_json(json Any) {
+pub fn (mut responses Responses) from_json(json Any) ? {
 	for key, value in json.as_map() {
 		match key {
 			'default' {
-				responses.default_response = from_json<Response>(value.json_str())
+				responses.default_response = from_json<Response>(value.json_str()) ?
 			}
 			// Todo finish status code
 			else {}
@@ -31,9 +31,9 @@ pub mut:
 	links       map[string]ObjectRef<Link>
 }
 
-pub fn (mut response Response) from_json(json Any) {
+pub fn (mut response Response) from_json(json Any) ? {
 	object := json.as_map()
-	check_required<Response>(object, 'description')
+	check_required<Response>(object, 'description') ?
 
 	for key, value in object {
 		match key {
@@ -42,17 +42,17 @@ pub fn (mut response Response) from_json(json Any) {
 			}
 			'headers' {
 				response.headers = decode_map_sumtype<Header>(value.json_str(), fake_predicat) or {
-					panic('Failed Response decoding: $err')
+					return error('Failed Response decoding: $err')
 				}
 			}
 			'content' {
 				response.content = decode_map<MediaType>(value.json_str()) or {
-					panic('Failed Response decoding: $err')
+					return error('Failed Response decoding: $err')
 				}
 			}
 			'links' {
 				response.links = decode_map_sumtype<Link>(value.json_str(), fake_predicat) or {
-					panic('Failed Response decoding: $err')
+					return error('Failed Response decoding: $err')
 				}
 			}
 			else {}

--- a/open_api/security.v
+++ b/open_api/security.v
@@ -1,6 +1,6 @@
 module open_api
 
-import x.json2 { Any, decode }
+import x.json2 { Any }
 import json
 
 struct SecurityRequirement {
@@ -8,7 +8,7 @@ pub mut:
 	requirements map[string][]string // Todo: make it match the '{name}' type
 }
 
-pub fn (mut requirement SecurityRequirement) from_json(json Any) {
+pub fn (mut requirement SecurityRequirement) from_json(json Any) ? {
 	// Todo
 }
 
@@ -26,10 +26,9 @@ pub mut:
 	description         string
 }
 
-pub fn (mut security_scheme SecurityScheme) from_json(json Any) {
+pub fn (mut security_scheme SecurityScheme) from_json(json Any) ? {
 	object := json.as_map()
-	check_required<SecurityScheme>(object, 'type', 'in', 'openIdConnectUrl', 'name', 'scheme',
-		'flows')
+	check_required<SecurityScheme>(object, 'type') ?
 
 	for key, value in json.as_map() {
 		match key {
@@ -50,7 +49,7 @@ pub fn (mut security_scheme SecurityScheme) from_json(json Any) {
 			}
 			'security_scheme' {
 				security_scheme.flows = decode<OAuthFlows>(value.json_str()) or {
-					panic('Failed SecurityScheme decoding: $err')
+					return error('Failed SecurityScheme decoding: $err')
 				}
 			}
 			'bearerFormat' {
@@ -74,27 +73,27 @@ pub mut:
 	password           OAuthFlow
 }
 
-pub fn (mut flows OAuthFlows) from_json(json Any) {
+pub fn (mut flows OAuthFlows) from_json(json Any) ? {
 	for key, value in json.as_map() {
 		match key {
 			'clientCredentials' {
 				flows.client_credentials = decode<OAuthFlow>(value.json_str()) or {
-					panic('Failed OAuthFlows decoding: $err')
+					return error('Failed OAuthFlows decoding: $err')
 				}
 			}
 			'authorizationCode' {
 				flows.authorization_code = decode<OAuthFlow>(value.json_str()) or {
-					panic('Failed OAuthFlows decoding: $err')
+					return error('Failed OAuthFlows decoding: $err')
 				}
 			}
 			'implicit' {
 				flows.implicit = decode<OAuthFlow>(value.json_str()) or {
-					panic('Failed OAuthFlows decoding: $err')
+					return error('Failed OAuthFlows decoding: $err')
 				}
 			}
 			'password' {
 				flows.password = decode<OAuthFlow>(value.json_str()) or {
-					panic('Failed OAuthFlows decoding: $err')
+					return error('Failed OAuthFlows decoding: $err')
 				}
 			}
 			else {}
@@ -112,9 +111,9 @@ pub mut:
 	refresh_url       string
 }
 
-pub fn (mut flow OAuthFlow) from_json(json Any) {
+pub fn (mut flow OAuthFlow) from_json(json Any) ? {
 	object := json.as_map()
-	check_required<OAuthFlow>(object, 'authorizationUrl', 'tokenUrl', 'scopes')
+	check_required<OAuthFlow>(object, 'authorizationUrl', 'tokenUrl', 'scopes') ?
 
 	for key, value in object {
 		match key {
@@ -126,7 +125,7 @@ pub fn (mut flow OAuthFlow) from_json(json Any) {
 			}
 			'scopes' {
 				flow.scopes = decode_map_string(value.json_str()) or {
-					panic('Failed OAuthFlow decoding: $err')
+					return error('Failed OAuthFlow decoding: $err')
 				}
 			}
 			'refreshUrl' {

--- a/open_api/server.v
+++ b/open_api/server.v
@@ -10,9 +10,9 @@ pub mut:
 	variables   map[string]ServerVariable
 }
 
-pub fn (mut server Server) from_json(json Any) {
+pub fn (mut server Server) from_json(json Any) ? {
 	object := json.as_map()
-	check_required<Server>(object, 'url')
+	check_required<Server>(object, 'url') ?
 
 	for key, value in object {
 		match key {
@@ -24,7 +24,7 @@ pub fn (mut server Server) from_json(json Any) {
 			}
 			'variables' {
 				server.variables = decode_map<ServerVariable>(value.json_str()) or {
-					panic('Failed Server decoding: $err')
+					return error('Failed Server decoding: $err')
 				}
 			}
 			else {}
@@ -41,9 +41,9 @@ pub mut:
 	description   string
 }
 
-pub fn (mut server_variable ServerVariable) from_json(json Any) {
+pub fn (mut server_variable ServerVariable) from_json(json Any) ? {
 	object := json.as_map()
-	check_required<ServerVariable>(object, 'default')
+	check_required<ServerVariable>(object, 'default') ?
 
 	for key, value in object {
 		match key {

--- a/open_api/tag.v
+++ b/open_api/tag.v
@@ -1,6 +1,6 @@
 module open_api
 
-import x.json2 { Any, decode }
+import x.json2 { Any }
 import json
 
 struct Tag {
@@ -10,9 +10,9 @@ pub mut:
 	description   string
 }
 
-pub fn (mut tag Tag) from_json(json Any) {
+pub fn (mut tag Tag) from_json(json Any) ? {
 	object := json.as_map()
-	check_required<Tag>(object, 'name')
+	check_required<Tag>(object, 'name') ?
 
 	for key, value in object {
 		match key {
@@ -21,7 +21,7 @@ pub fn (mut tag Tag) from_json(json Any) {
 			}
 			'externalDocs' {
 				tag.external_docs = decode<ExternalDocumentation>(value.json_str()) or {
-					panic('Failed Tag decoding: $err')
+					return error('Failed Tag decoding: $err')
 				}
 			}
 			'description' {

--- a/open_api/testdata/components.json
+++ b/open_api/testdata/components.json
@@ -1,0 +1,102 @@
+{
+    "schemas": {
+      "GeneralError": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "message": {
+            "type": "string"
+          }
+        }
+      },
+      "Category": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "Tag": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "parameters": {
+      "skipParam": {
+        "name": "skip",
+        "in": "query",
+        "description": "number of items to skip",
+        "required": true,
+        "schema": {
+          "type": "integer",
+          "format": "int32"
+        }
+      },
+      "limitParam": {
+        "name": "limit",
+        "in": "query",
+        "description": "max records to return",
+        "required": true,
+        "schema" : {
+          "type": "integer",
+          "format": "int32"
+        }
+      },
+      "test": {
+        "$ref": "#/components/schemas/UUID"
+      }
+    },
+    "responses": {
+      "NotFound": {
+        "description": "Entity not found."
+      },
+      "IllegalInput": {
+        "description": "Illegal input for operation."
+      },
+      "GeneralError": {
+        "description": "General Error",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/GeneralError"
+            }
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "api_key": {
+        "type": "apiKey",
+        "name": "api_key",
+        "in": "header"
+      },
+      "petstore_auth": {
+        "type": "oauth2",
+        "flows": {
+          "implicit": {
+            "authorizationUrl": "http://example.org/api/oauth/dialog",
+            "scopes": {
+              "write:pets": "modify pets in your account",
+              "read:pets": "read your pets"
+            }
+          }
+        }
+      }
+    }
+}

--- a/open_api/tests/callback_test.v
+++ b/open_api/tests/callback_test.v
@@ -1,10 +1,9 @@
 import open_api
-import x.json2
 import os
 
 fn test_callback_struct() ? {
 	content := os.read_file(@VMODROOT + '/open_api/testdata/callback.json') ?
-	components := json2.decode<open_api.Components>(content) ?
+	components := open_api.decode<open_api.Components>(content) ?
 	callback := components.callbacks['test1'] as open_api.Callback
 
 	assert callback.len == 2

--- a/open_api/tests/components_test.v
+++ b/open_api/tests/components_test.v
@@ -1,0 +1,12 @@
+import open_api
+import os
+
+fn test_components_struct() ? {
+	content := os.read_file(@VMODROOT + '/open_api/testdata/components.json') ?
+	components := open_api.decode<open_api.Components>(content) ?
+
+	assert components.schemas.len == 3
+	assert components.parameters.len == 3
+	assert components.responses.len == 3
+	assert components.security_schemes.len == 2
+}

--- a/open_api/tests/info_test.v
+++ b/open_api/tests/info_test.v
@@ -1,10 +1,9 @@
 import open_api
-import x.json2
 import os
 
 fn test_basic_info_struct() ? {
 	content := '{ "title": "random", "version": "1.0.1" }'
-	info := json2.decode<open_api.Info>(content) ?
+	info := open_api.decode<open_api.Info>(content) ?
 	assert info.title == 'random'
 	assert info.version == '1.0.1'
 }
@@ -15,7 +14,7 @@ fn test_info_struct_without_required() ? {
 
 fn test_full_info_struct() ? {
 	content := os.read_file(@VMODROOT + '/open_api/testdata/info.json') ?
-	info := json2.decode<open_api.Info>(content) ?
+	info := open_api.decode<open_api.Info>(content) ?
 	assert info.title == 'Sample Pet Store App'
 	assert info.version == '1.0.1'
 	assert info.description == 'This is a sample server for a pet store.'

--- a/open_api/tests/info_test.v
+++ b/open_api/tests/info_test.v
@@ -9,7 +9,9 @@ fn test_basic_info_struct() ? {
 }
 
 fn test_info_struct_without_required() ? {
-	// Todo: We need to wait the implementation of the recover keyword
+	content := '{ "title": "random" }'
+	info := open_api.decode<open_api.Info>(content) or { return }
+	assert false
 }
 
 fn test_full_info_struct() ? {

--- a/open_api/tests/openapi_test.v
+++ b/open_api/tests/openapi_test.v
@@ -1,10 +1,9 @@
 import open_api
-import x.json2
 import os
 
 fn test_basic_open_api_struct() ? {
 	content := os.read_file(@VMODROOT + '/open_api/testdata/open_api_basic.json') ?
-	open_api := json2.decode<open_api.OpenApi>(content) ?
+	open_api := open_api.decode<open_api.OpenApi>(content) ?
 	assert open_api.openapi == '3'
 	assert open_api.info.title == 'Sample Pet Store App'
 	assert open_api.info.version == '1.0.1'

--- a/open_api/tests/openapi_test.v
+++ b/open_api/tests/openapi_test.v
@@ -22,8 +22,22 @@ fn test_basic_open_api_struct() ? {
 	assert open_api.servers[0].variables['var1'].default_value == 'default'
 }
 
-fn test_open_api_struct_without_required() ? {
-	// Todo: We need to wait the implementation of the recover keyword
+fn test_open_api_struct_without_paths() ? {
+	content := '{ "openapi": "3", "info": {"title": "oui", "version": "1"} }'
+	info := open_api.decode<open_api.OpenApi>(content) or { return }
+	assert false
+}
+
+fn test_open_api_struct_without_info() ? {
+	content := '{ "openapi": "3", "paths": {} }'
+	info := open_api.decode<open_api.OpenApi>(content) or { return }
+	assert false
+}
+
+fn test_open_api_struct_without_openapi() ? {
+	content := '{ "info": {"title": "oui", "version": "1"}, "paths": {} }'
+	info := open_api.decode<open_api.OpenApi>(content) or { return }
+	assert false
 }
 
 fn test_full_open_api_struct() ? {


### PR DESCRIPTION
## Goal:
This PR was supposed to totally finish implementing the component struct by addind the custom contraint of the openapi spec.
To make the sumtypes work, here is what i did:
- Use custom `decode` func that allow `from_json` to return optionnal
- replace all `from_json` prototypes
- Adapt the whole module to use `error` instead of `panic`

As we use `error`, i also managed to implement missing tests for `OpenApi` and `Info` structs

## Todo before merge:
- [x] Test It  !
- [x] Make the sumtypes work as intended 
 
## Todo in another PR:
