### PR TITLE
[Add] Complete Responses structs

### DIFF
--- a/open_api/helpers.v
+++ b/open_api/helpers.v
@@ -109,3 +109,10 @@ fn check_email_regex(str string) bool {
 	}
 	return reg.matches_string(str)
 }
+
+fn check_http_code_regex(str string) bool {
+	mut reg := regex.regex_opt(r'^([1-5][\d][\d])|([1-5]XX)$') or {
+		panic('Failed to initialize regex expression')
+	}
+	return reg.matches_string(str)
+}

--- a/open_api/testdata/responses.json
+++ b/open_api/testdata/responses.json
@@ -1,0 +1,22 @@
+{
+    "200": {
+      "description": "a pet to be returned",
+      "content": {
+        "application/json": {
+          "schema": {
+            "$ref": "#/components/schemas/Pet"
+          }
+        }
+      }
+    },
+    "default": {
+      "description": "Unexpected error",
+      "content": {
+        "application/json": {
+          "schema": {
+            "$ref": "#/components/schemas/ErrorModel"
+          }
+        }
+      }
+    }
+}

--- a/open_api/tests/operation_test.v
+++ b/open_api/tests/operation_test.v
@@ -9,6 +9,6 @@ fn test_operation_struct() ? {
 	assert operation.summary == 'Updates a pet in the store with form data'
 	assert operation.operation_id == 'updatePetWithForm'
 	assert operation.parameters.len == 1
-	// assert operation.responses.len == 2 Todo: Correct it once Response is done
+	assert operation.responses.len == 2
 	assert operation.security.len == 1
 }

--- a/open_api/tests/path_item_test.v
+++ b/open_api/tests/path_item_test.v
@@ -8,7 +8,6 @@ fn test_path_item_struct() ? {
 	assert path_item.get.description == 'Returns pets based on ID'
 	assert path_item.get.summary == 'Find pets by ID'
 	assert path_item.get.operation_id == 'getPetsById'
-	// assert path_item.get.responses.len == 1 Todo: fix when responses is finished
-
+	assert path_item.get.responses.len == 1
 	assert path_item.parameters.len == 1
 }

--- a/open_api/tests/responses_test.v
+++ b/open_api/tests/responses_test.v
@@ -1,0 +1,17 @@
+import open_api
+import os
+
+fn test_responses_struct() ? {
+	content := os.read_file(@VMODROOT + '/open_api/testdata/responses.json') ?
+	responses := open_api.decode<open_api.Responses>(content) ?
+
+	assert responses.len == 2
+
+	mut response := responses['200'] as open_api.Response
+	assert response.description == 'a pet to be returned'
+	assert 'application/json' in response.content
+
+	response = responses['default'] as open_api.Response
+	assert response.description == 'Unexpected error'
+	assert 'application/json' in response.content
+}


### PR DESCRIPTION
## Goal:
The goal of this PR is to find a way to correctly implement the `Responses` struct, then to add OpenApi3 specs constraints on `Responses` and `Response` structs.

We need to do the same tricks as the ones we used for the Callback structs to perfectly match the specs

## Todo before merge:
- [x] Test It  !
- [x] Find a way to implement Responses structs
- [x] Add constraints
 
## Todo in another PR:
