### PR TITLE
[Add] Implement Schema structs

### DIFF
--- a/open_api/components.v
+++ b/open_api/components.v
@@ -28,9 +28,7 @@ pub fn (mut components Components) from_json(json Any) ? {
 					check_key_regex) ?
 			}
 			'schemas' {
-				components.schemas = decode_map_sumtype<Schema>(value.json_str(), check_key_regex) or {
-					return error('Failed Components decoding: $err')
-				}
+				components.schemas = decode_map_sumtype<Schema>(value.json_str(), check_key_regex) ?
 			}
 			'responses' {
 				components.responses = decode_map_sumtype<Response>(value.json_str(),
@@ -41,19 +39,13 @@ pub fn (mut components Components) from_json(json Any) ? {
 					check_key_regex) ?
 			}
 			'examples' {
-				components.examples = decode_map_sumtype<Example>(value.json_str(), check_key_regex) or {
-					return error('Failed Components decoding: $err')
-				}
+				components.examples = decode_map_sumtype<Example>(value.json_str(), check_key_regex) ?
 			}
 			'headers' {
-				components.headers = decode_map_sumtype<Header>(value.json_str(), check_key_regex) or {
-					return error('Failed Components decoding: $err')
-				}
+				components.headers = decode_map_sumtype<Header>(value.json_str(), check_key_regex) ?
 			}
 			'links' {
-				components.links = decode_map_sumtype<Link>(value.json_str(), check_key_regex) or {
-					return error('Failed Components decoding: $err')
-				}
+				components.links = decode_map_sumtype<Link>(value.json_str(), check_key_regex) ?
 			}
 			'callbacks' {
 				components.callbacks = decode_map_sumtype<Callback>(value.json_str(),
@@ -62,4 +54,25 @@ pub fn (mut components Components) from_json(json Any) ? {
 			else {}
 		}
 	}
+	components.validate() ?
+}
+
+fn check_keys(keys []string) ? {
+	keys.map(fn (key string) ? {
+		if !check_key_regex(key) {
+			return error('Failed Components Decoding: $key do not respect key regex format.')
+		}
+	})
+}
+
+fn (mut components Components) validate() ? {
+	check_keys(components.security_schemes.keys()) ?
+	check_keys(components.request_bodies.keys()) ?
+	check_keys(components.schemas.keys()) ?
+	check_keys(components.responses.keys()) ?
+	check_keys(components.parameters.keys()) ?
+	check_keys(components.examples.keys()) ?
+	check_keys(components.headers.keys()) ?
+	check_keys(components.links.keys()) ?
+	check_keys(components.callbacks.keys()) ?
 }

--- a/open_api/helpers.v
+++ b/open_api/helpers.v
@@ -30,6 +30,13 @@ pub fn decode_array_string(src string) ?[]string {
 	})
 }
 
+pub fn decode_array_any(src string) ?[]Any {
+	json := raw_decode(src) ?
+	return json.arr().map(fn (elt Any) Any {
+		return elt
+	})
+}
+
 // ---------------------------------------- //
 
 pub fn decode_map<T>(src string) ?map[string]T {

--- a/open_api/helpers.v
+++ b/open_api/helpers.v
@@ -25,12 +25,9 @@ pub fn decode_array<T>(src string) ?[]T {
 
 pub fn decode_array_string(src string) ?[]string {
 	json := raw_decode(src) ?
-	mut typ := []string{}
-
-	for value in json.arr() {
-		typ << value.str()
-	}
-	return typ
+	return json.arr().map(fn (elt Any) string {
+		return elt.str()
+	})
 }
 
 // ---------------------------------------- //

--- a/open_api/openapi.v
+++ b/open_api/openapi.v
@@ -7,7 +7,7 @@ struct OpenApi {
 pub mut:
 	openapi       string
 	info          Info
-	paths         map[string]PathItem
+	paths         Paths
 	external_docs ExternalDocumentation
 	servers       []Server
 	components    Components
@@ -28,7 +28,7 @@ pub fn (mut open_api OpenApi) from_json(json Any) ? {
 				open_api.info = decode<Info>(value.json_str()) ?
 			}
 			'paths' {
-				open_api.paths = decode<map[string]PathItem>(value.json_str()) ?
+				open_api.paths = decode<Paths>(value.json_str()) ?
 			}
 			'externalDocs' {
 				open_api.external_docs = decode<ExternalDocumentation>(value.json_str()) ?
@@ -48,13 +48,4 @@ pub fn (mut open_api OpenApi) from_json(json Any) ? {
 			else {}
 		}
 	}
-}
-
-// ---------------------------------------- //
-
-struct Schema {
-	// Todo: flemme
-}
-
-pub fn (mut schema Schema) from_json(json Any) ? {
 }

--- a/open_api/path_item.v
+++ b/open_api/path_item.v
@@ -102,14 +102,14 @@ fn clean_path_expression(path string) string {
 pub fn (mut paths Paths) from_json(json Any) ? {
 	mut save_value := map[string][]string{}
 	mut tmp := map[string]PathItem{}
-	
+
 	for key, value in json.as_map() {
 		if !key.starts_with('/') {
 			return error('Failed Paths decoding: path do not start with "/" !')
 		}
 
 		value_key := value.as_map().keys()
-		
+
 		for path in tmp.keys() {
 			value_ref := save_value[path]
 

--- a/open_api/reference.v
+++ b/open_api/reference.v
@@ -1,6 +1,7 @@
 module open_api
 
 import x.json2 { Any, raw_decode }
+import json
 
 struct Reference {
 pub mut:

--- a/open_api/reference.v
+++ b/open_api/reference.v
@@ -1,7 +1,6 @@
 module open_api
 
 import x.json2 { Any, raw_decode }
-import json
 
 struct Reference {
 pub mut:
@@ -39,7 +38,7 @@ pub fn from_json<T>(json Any) ?ObjectRef<T> {
 
 pub fn (mut object []ObjectRef<Parameter>) from_json(json Any) ? {
 	for value in json.arr() {
-		str := raw_decode(value.json_str()) or { return error('') }
+		str := raw_decode(value.json_str()) ?
 		object << from_json<Parameter>(str) ?
 	}
 }

--- a/open_api/schema.v
+++ b/open_api/schema.v
@@ -4,9 +4,12 @@ import x.json2 { Any }
 import json
 
 struct Schema {
+pub mut:
 	title             string
 	multiple_of       f64
 	maximum           f64
+	minimum           f64
+	exclusive_maximum bool
 	exclusive_minimum bool
 	max_length        u64
 	min_length        u64
@@ -42,20 +45,173 @@ struct Schema {
 }
 
 pub fn (mut schema Schema) from_json(json Any) ? {
+	for key, value in json.as_map() {
+		match key {
+			'title' {
+				schema.title = value.str()
+			}
+			'pattern' {
+				schema.pattern = value.str()
+			}
+			'type' {
+				schema.type_schema = value.str()
+			}
+			'description' {
+				schema.description = value.str()
+			}
+			'format' {
+				schema.format = value.str()
+			}
+			'multipleOf' {
+				schema.multiple_of = value.f64()
+			}
+			'maximum' {
+				schema.maximum = value.f64()
+			}
+			'minimum' {
+				schema.minimum = value.f64()
+			}
+			'maxLength' {
+				schema.max_length = value.u64()
+			}
+			'minLength' {
+				schema.min_length = value.u64()
+			}
+			'maxItems' {
+				schema.max_items = value.u64()
+			}
+			'minItems' {
+				schema.min_items = value.u64()
+			}
+			'maxProperties' {
+				schema.max_properties = value.u64()
+			}
+			'minProperties' {
+				schema.min_properties = value.u64()
+			}
+			'exclusiveMinimum' {
+				schema.exclusive_minimum = value.bool()
+			}
+			'exclusiveMaximum' {
+				schema.exclusive_maximum = value.bool()
+			}
+			'UniqueItems' {
+				schema.unique_items = value.bool()
+			}
+			'nullable' {
+				schema.nullable = value.bool()
+			}
+			'readOnly' {
+				schema.read_only = value.bool()
+			}
+			'writeOnly' {
+				schema.write_only = value.bool()
+			}
+			'deprecated' {
+				schema.deprecated = value.bool()
+			}
+			'default' {
+				schema.default_value = value
+			}
+			'example' {
+				schema.example = value
+			}
+			'discriminator' {
+				schema.discriminator = decode<Discriminator>(value.json_str()) ?
+			}
+			'xml' {
+				schema.xml = decode<XML>(value.json_str()) ?
+			}
+			'externalDocs' {
+				schema.external_docs = decode<ExternalDocumentation>(value.json_str()) ?
+			}
+			'allOf' {
+				schema.all_of = from_json<Schema>(value) ?
+			}
+			'oneOf' {
+				schema.one_of = from_json<Schema>(value) ?
+			}
+			'anyOf' {
+				schema.any_of = from_json<Schema>(value) ?
+			}
+			'not' {
+				schema.not = from_json<Schema>(value) ?
+			}
+			'items' {
+				schema.items = from_json<Schema>(value) ?
+			}
+			'additionalProperties' {
+				schema.additional_properties = from_json<Schema>(value) ?
+			}
+			'required' {
+				schema.required = decode_array_string(value.json_str()) ?
+			}
+			'enum' {
+				schema.enum_values = decode_array_any(value.json_str()) ?
+			}
+			'properties' {
+				schema.properties = decode_map_sumtype<Schema>(value.json_str(), fake_predicat) ?
+			}
+			else {}
+		}
+	}
 }
 
 // ---------------------------------------- //
 
 struct Discriminator {
+pub mut:
+	property_name string
+	mapping       map[string]string
 }
 
 pub fn (mut discriminator Discriminator) from_json(json Any) ? {
+	object := json.as_map()
+	check_required<Discriminator>(object, 'propertyName') ?
+
+	for key, value in object {
+		match key {
+			'propertyName' {
+				discriminator.property_name == value.str()
+			}
+			'mapping' {
+				discriminator.mapping == decode_map_string(value.json_str()) ?
+			}
+			else {}
+		}
+	}
 }
 
 // ---------------------------------------- //
 
 struct XML {
+pub mut:
+	name      string
+	namespace string
+	prefix    string
+	attribute bool
+	wrapped   bool
 }
 
 pub fn (mut xml XML) from_json(json Any) ? {
+	for key, value in json.as_map() {
+		match key {
+			'name' {
+				xml.name == value.str()
+			}
+			'namespace' {
+				xml.namespace == value.str()
+			}
+			'prefix' {
+				xml.prefix == value.str()
+			}
+			'attribute' {
+				xml.attribute == value.bool()
+			}
+			'wrapped' {
+				xml.wrapped == value.bool()
+			}
+			else {}
+		}
+	}
 }

--- a/open_api/schema.v
+++ b/open_api/schema.v
@@ -223,10 +223,10 @@ pub fn (mut discriminator Discriminator) from_json(json Any) ? {
 	for key, value in object {
 		match key {
 			'propertyName' {
-				discriminator.property_name == value.str()
+				discriminator.property_name = value.str()
 			}
 			'mapping' {
-				discriminator.mapping == decode_map_string(value.json_str()) ?
+				discriminator.mapping = decode_map_string(value.json_str()) ?
 			}
 			else {}
 		}
@@ -248,19 +248,19 @@ pub fn (mut xml XML) from_json(json Any) ? {
 	for key, value in json.as_map() {
 		match key {
 			'name' {
-				xml.name == value.str()
+				xml.name = value.str()
 			}
 			'namespace' {
-				xml.namespace == value.str()
+				xml.namespace = value.str()
 			}
 			'prefix' {
-				xml.prefix == value.str()
+				xml.prefix = value.str()
 			}
 			'attribute' {
-				xml.attribute == value.bool()
+				xml.attribute = value.bool()
 			}
 			'wrapped' {
-				xml.wrapped == value.bool()
+				xml.wrapped = value.bool()
 			}
 			else {}
 		}

--- a/open_api/schema.v
+++ b/open_api/schema.v
@@ -1,0 +1,61 @@
+module open_api
+
+import x.json2 { Any }
+import json
+
+struct Schema {
+	title             string
+	multiple_of       f64
+	maximum           f64
+	exclusive_minimum bool
+	max_length        u64
+	min_length        u64
+	pattern           string
+	max_items         u64
+	min_items         u64
+	unique_items      bool
+	max_properties    u64
+	min_properties    u64
+	required          []string
+	enum_values       []Any
+
+	type_schema           string
+	all_of                ObjectRef<Schema>
+	one_of                ObjectRef<Schema>
+	any_of                ObjectRef<Schema>
+	not                   ObjectRef<Schema>
+	items                 ObjectRef<Schema>
+	properties            map[string]ObjectRef<Schema>
+	additional_properties ObjectRef<Schema>
+	description           string
+	format                string
+	default_value         Any
+
+	nullable      bool
+	discriminator Discriminator
+	read_only     bool
+	write_only    bool
+	xml           XML
+	external_docs ExternalDocumentation
+	example       Any
+	deprecated    bool
+}
+
+pub fn (mut schema Schema) from_json(json Any) ? {
+}
+
+// ---------------------------------------- //
+
+struct Discriminator {
+}
+
+pub fn (mut discriminator Discriminator) from_json(json Any) ? {
+}
+
+// ---------------------------------------- //
+
+struct XML {
+}
+
+pub fn (mut xml XML) from_json(json Any) ? {
+}

--- a/open_api/testdata/open_api_complex.yaml
+++ b/open_api/testdata/open_api_complex.yaml
@@ -1068,10 +1068,6 @@ paths:
       responses:
         "200":
           description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PutTraceBatchResponse'
   /trace/{activity}/{assignment}/{submission}/{index}/{login}:
     post:
       tags:
@@ -1268,8 +1264,6 @@ components:
           $ref: '#/components/schemas/UUID'
         status:
           $ref: '#/components/schemas/Status2'
-    JsonNode:
-      type: array
     MultivaluedMapStringString:
       type: object
       additionalProperties:
@@ -1321,8 +1315,6 @@ components:
       properties:
         payloadType:
           type: string
-        payload:
-          $ref: '#/components/schemas/JsonNode'
     PutTraceBatchRequest:
       type: object
       properties:
@@ -1335,8 +1327,6 @@ components:
           type: string
         traceArchiveUrl:
           type: string
-    PutTraceBatchResponse:
-      type: array
     Request:
       required:
       - batchId

--- a/open_api/testdata/open_api_complex.yaml
+++ b/open_api/testdata/open_api_complex.yaml
@@ -701,10 +701,10 @@ paths:
     get:
       tags:
       - Recovery Resource
-      description: "Get the job recovering service configuration: \\n - batchSize:\
-        \ maximum number of jobs retried per trigger.\\n - maxMinutesLag: number of\
+      description: "Get the job recovering service configuration: \n - batchSize:\
+        \ maximum number of jobs retried per trigger.\n - maxMinutesLag: number of\
         \ minutes before a job in a transitory state is considered lost, and thus,\
-        \ eligible to recovery. \\n - retryMax: maximum number of automatic retries\
+        \ eligible to recovery. \n - retryMax: maximum number of automatic retries\
         \ before the job is considered unsalvageable and locked (manual retries don't\
         \ increment)."
       responses:
@@ -717,10 +717,10 @@ paths:
     put:
       tags:
       - Recovery Resource
-      description: "Set the job recovering service configuration: \\n - batchSize:\
-        \ maximum number of jobs retried per trigger.\\n - maxMinutesLag: number of\
+      description: "Set the job recovering service configuration: \n - batchSize:\
+        \ maximum number of jobs retried per trigger.\n - maxMinutesLag: number of\
         \ minutes before a job in a transitory state is considered lost, and thus,\
-        \ eligible to recovery. \\n - retryMax: maximum number of automatic retries\
+        \ eligible to recovery. \n - retryMax: maximum number of automatic retries\
         \ before the job is considered unsalvageable and locked (manual retries don't\
         \ increment)."
       requestBody:
@@ -1763,19 +1763,19 @@ components:
       type: object
       properties:
         activitySlug:
-          pattern: \\S
+          pattern: \S
           type: string
           nullable: false
         assignmentSlug:
-          pattern: \\S
+          pattern: \S
           type: string
           nullable: false
         fromSubmissionSlug:
-          pattern: \\S
+          pattern: \S
           type: string
           nullable: false
         toSubmissionSlug:
-          pattern: \\S
+          pattern: \S
           type: string
           nullable: false
     ValidatedSubmission:

--- a/open_api/testdata/operation.json
+++ b/open_api/testdata/operation.json
@@ -13,6 +13,9 @@
         "schema": {
           "type": "string"
         }
+      },
+      {
+          "$ref": "Here_is_a_ref"
       }
     ],
     "requestBody": {

--- a/open_api/testdata/schema.json
+++ b/open_api/testdata/schema.json
@@ -1,0 +1,72 @@
+{
+    "schemas": {
+      "Pet": {
+        "type": "object",
+        "discriminator": {
+          "propertyName": "petType"
+        },
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "petType": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "petType"
+        ]
+      },
+      "Cat": {
+        "description": "A representation of a cat. Note that `Cat` will be used as the discriminator value.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Pet"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "huntingSkill": {
+                "type": "string",
+                "description": "The measured skill for hunting",
+                "default": "lazy",
+                "enum": [
+                  "clueless",
+                  "lazy",
+                  "adventurous",
+                  "aggressive"
+                ]
+              }
+            },
+            "required": [
+              "huntingSkill"
+            ]
+          }
+        ]
+      },
+      "Dog": {
+        "description": "A representation of a dog. Note that `Dog` will be used as the discriminator value.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Pet"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "packSize": {
+                "type": "integer",
+                "format": "int32",
+                "description": "the size of the pack the dog is from",
+                "default": 0,
+                "minimum": 0
+              }
+            },
+            "required": [
+              "packSize"
+            ]
+          }
+        ]
+      }
+    }
+}

--- a/open_api/tests/openapi_test.v
+++ b/open_api/tests/openapi_test.v
@@ -1,6 +1,7 @@
 import open_api
 import yaml
 import os
+import regex
 
 fn test_basic_open_api_struct() ? {
 	content := os.read_file(@VMODROOT + '/open_api/testdata/open_api_basic.json') ?
@@ -41,8 +42,23 @@ fn test_open_api_struct_without_openapi() ? {
 	assert false
 }
 
+fn escape_escaped_char(str string) ?string {
+	mut tmp := str.clone()
+	mut checked := []string{}
+
+	mut reg := regex.regex_opt(r'\\[a-zA-Z]') ?
+	for char in reg.find_all_str(str) {
+		if char in checked { continue }
+		tmp = tmp.replace(char, '\\$char')
+		checked << char
+	}
+
+	return tmp
+}
+
 fn test_full_open_api_struct() ? {
-	content := os.read_file(@VMODROOT + '/open_api/testdata/open_api_complex.yaml') ?
+	mut content := os.read_file(@VMODROOT + '/open_api/testdata/open_api_complex.yaml') ?
+	content = escape_escaped_char(content) ?
 	json := yaml.yaml_to_json(content, replace_tags: true) ?
 	open_api := open_api.decode<open_api.OpenApi>(json) ?
 }

--- a/open_api/tests/openapi_test.v
+++ b/open_api/tests/openapi_test.v
@@ -48,7 +48,9 @@ fn escape_escaped_char(str string) ?string {
 
 	mut reg := regex.regex_opt(r'\\[a-zA-Z]') ?
 	for char in reg.find_all_str(str) {
-		if char in checked { continue }
+		if char in checked {
+			continue
+		}
 		tmp = tmp.replace(char, '\\$char')
 		checked << char
 	}

--- a/open_api/tests/operation_test.v
+++ b/open_api/tests/operation_test.v
@@ -8,7 +8,14 @@ fn test_operation_struct() ? {
 	assert operation.tags.len == 1
 	assert operation.summary == 'Updates a pet in the store with form data'
 	assert operation.operation_id == 'updatePetWithForm'
-	assert operation.parameters.len == 1
+	assert operation.parameters.len == 2
+
+	parameter := operation.parameters[0] as open_api.Parameter
+	assert parameter.name == 'petId'
+
+	ref := operation.parameters[1] as open_api.Reference
+	assert ref.ref == 'Here_is_a_ref'
+
 	assert operation.responses.len == 2
 	assert operation.security.len == 1
 }

--- a/open_api/tests/schema_test.v
+++ b/open_api/tests/schema_test.v
@@ -1,0 +1,14 @@
+import open_api
+import os
+
+fn test_schema_struct() ? {
+	content := os.read_file(@VMODROOT + '/open_api/testdata/schema.json') ?
+	components := open_api.decode<open_api.Components>(content) ?
+	assert components.schemas.len == 3
+
+	mut schema := components.schemas['Pet'] as open_api.Schema
+	assert schema.type_schema == 'object'
+	assert schema.discriminator.property_name == 'petType'
+	assert schema.properties.len == 2
+	assert schema.required == ['name', 'petType']
+}


### PR DESCRIPTION
## Goal:
The goal of this PR is to implement the Schema, Discriminator and XML structs and there constraints from OpenApi3.

This PR also:
- add constraints on the Components structs.
- Properly handle escaped character on yaml file before parsing into json
- Refacto a bit of some things  

## Todo before merge:
- [x] Implement Schema struct
- [x] Implement Discriminator struct
- [x] Implement XML struct
- [x] Implement Constraints on them
- [x] Properly handle escaped characters before parsing 
- [x] Refacto
- [x] Test everything 
 
## Todo in another PR:
- Add all the difficult constraints on each struct to perfectly handle all cases
