### PR TITLE
[Refacto] Merge 'body' and 'body_stdin' flags 

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,7 @@
 ## Goal:
 
+Closes #Todo
+
 ## Todo before merge:
 - [x] Test It  !
  

--- a/cli_builder/templates/cli.tmpl
+++ b/cli_builder/templates/cli.tmpl
@@ -26,7 +26,6 @@ fn main() {
 
 	mut cmd := cli.Command{}
 	mut cmds := []cli.Command{}
-	mut content_types := []string{}
 @for path, path_item in api.paths
 	@for method, operation in path_item.get_operations()
 	// -------------- New Command -------------- //
@@ -39,18 +38,18 @@ fn main() {
 										@operation.get_request_body().content.keys(), cmd) ?
 		}
     }
-
-	cmds << cmd
-
-	content_types = @operation.get_request_body().content.keys()
-	if content_types.len > 0 {
-        add_flag(mut cmd, cli.FlagType.string, 'body', false)
-	}
+	@if operation.get_request_body().content.keys().len > 0
+    add_flag(mut cmd, cli.FlagType.string, 'body', false)
+	@end
 	@for parameter in operation.get_path_parameters()
 	add_flag(mut cmd, cli.FlagType.string, '@parameter.name', @parameter.required)
 	@end
+	cmds << cmd
 	@end
 @end
+
+	// ----------------------------------------- //
+
     app.add_commands(cmds)
     app.setup()
     app.parse(os.args)

--- a/cli_builder/templates/cli.tmpl
+++ b/cli_builder/templates/cli.tmpl
@@ -5,9 +5,9 @@ import cli_builder
 import os
 import x.json2 { Any }
 
-fn add_flag(mut cmd cli.Command, flag cli.FlagType, name string, required bool) {
+fn add_flag(mut cmd cli.Command, name string, required bool) {
 	cmd.add_flag(cli.Flag{
-		flag: flag
+		flag: cli.FlagType.string
 		name: name
 		required: required
 	})
@@ -39,10 +39,10 @@ fn main() {
 		}
     }
 	@if operation.get_request_body().content.keys().len > 0
-    add_flag(mut cmd, cli.FlagType.string, 'body', false)
+    add_flag(mut cmd, 'body', true)
 	@end
 	@for parameter in operation.get_path_parameters()
-	add_flag(mut cmd, cli.FlagType.string, '@parameter.name', @parameter.required)
+	add_flag(mut cmd, '@parameter.name', @parameter.required)
 	@end
 	cmds << cmd
 	@end

--- a/cli_builder/utils.v
+++ b/cli_builder/utils.v
@@ -31,36 +31,29 @@ fn get_fetch_config(method string, url string, data string) http.FetchConfig {
 	}
 }
 
+fn get_stdin_input() ?string {
+	mut input := ''
+	for {
+		str := os.input_opt('') or { break }
+		input += str
+	}
+	return input
+}
+
 pub fn execute_command(method string, path string, content_types []string, cmd cli.Command) ? {
-	flags := cmd.flags.get_all_found()
-	flags_name := flags.map(fn (elt cli.Flag) string {
-		return elt.name
-	})
-
-	if 'body' in flags_name && 'body_stdin' in flags_name {
-		println("Error: You cant use 'body' and 'body_stdin' simultaneously")
-		return
-	}
-
-	if method in ['PUT', 'POST', 'PATCH'] && 'body' !in flags_name && 'body_stdin' !in flags_name {
-		println('Error: Specifying a body is mandatory for this operation.')
-		return
-	}
-
 	mut data := ''
 	mut url := path
-	for flag in flags {
-		if flag.flag == cli.FlagType.string {
-			if flag.name != 'body' {
-				url = url.replace('{' + flag.name + '}', flag.get_string() ?)
-			} else {
-				data = flag.get_string() ?
-			}
+
+	for flag in cmd.flags.get_all_found() {
+		if flag.name != 'body' {
+			url = url.replace('{' + flag.name + '}', flag.get_string() ?)
+		} else {
+			data = flag.get_string() ?
 		}
 	}
 
-	if 'body_stdin' in flags_name {
-		data = os.input('Enter request body:\n')
+	if data == '-' {
+		data = get_stdin_input() ?
 	} else if os.is_file(data) {
 		data = os.read_file(data) ?
 	}

--- a/open_api/tests/path_item_test.v
+++ b/open_api/tests/path_item_test.v
@@ -16,5 +16,5 @@ fn test_path_item_operations_map() ? {
 	content := os.read_file(@VMODROOT + '/open_api/testdata/path_item.json') ?
 	path_item := open_api.decode<open_api.PathItem>(content) ?
 
-	assert path_item.operations.keys() == ['GET']
+	assert path_item.get_operations().keys() == ['GET']
 }


### PR DESCRIPTION
## Goal:
The goal is to have only one flag to specify the request body.
To do so, we use the value '-' to specify that we want to read stdin.
It also add a bit of refactoring and bug fixing to have cleaner code and cleaner generated files

Closes #27

## Todo before merge:
- [x] Test It  !
- [x] Refacto template to have cleaner generated files 
 
## Todo in another PR:
Finish other issues