### PR TITLE
[Add] Set auth flag as required if specified in openApi spec

### DIFF
--- a/cli_builder/build.v
+++ b/cli_builder/build.v
@@ -4,7 +4,19 @@ import os
 import open_api
 import yaml
 
+fn is_basic_http_required(open_api open_api.OpenApi) bool {
+	security_schemes := open_api.components.get_basic_http_schemes()
+	mut required := false
+	for requirement in open_api.security {
+		for key, _ in requirement {
+			required = required || key in security_schemes
+		}
+	}
+	return required
+}
+
 fn render(open_api open_api.OpenApi) string {
+	required := is_basic_http_required(open_api)
 	api := open_api
 	return $tmpl('templates/cli.tmpl')
 }

--- a/cli_builder/templates/cli.tmpl
+++ b/cli_builder/templates/cli.tmpl
@@ -51,7 +51,7 @@ fn main() {
 
 	for mut command in cmds {
     	add_flag(mut command, cli.FlagType.string_array, 'header', 'H', false)
-    	add_flag(mut command, cli.FlagType.string, 'auth', 'u', false)
+    	add_flag(mut command, cli.FlagType.string, 'auth', 'u', @required)
 	}
 
     app.add_commands(cmds)

--- a/cli_builder/testdata/open_api.yaml
+++ b/cli_builder/testdata/open_api.yaml
@@ -742,3 +742,10 @@ components:
         tagTime:
           format: date-time
           type: string
+  securitySchemes:
+    http:
+      type: http
+      scheme: basic
+security:
+  - http:
+    - {}

--- a/open_api/components.v
+++ b/open_api/components.v
@@ -76,3 +76,20 @@ fn (mut components Components) validate() ? {
 	check_keys(components.links.keys()) ?
 	check_keys(components.callbacks.keys()) ?
 }
+
+pub fn (components Components) get_basic_http_schemes() []string {
+	mut keys := []string{}
+
+	for key, value in components.security_schemes {
+		if value is SecurityScheme {
+			tmp := SecurityScheme{
+				...value
+			}
+			if tmp.security_type.to_lower() == 'http' && tmp.scheme.to_lower() == 'basic' {
+				keys << key
+			}
+		}
+	}
+
+	return keys
+}


### PR DESCRIPTION
## Goal:
This PR is setting the auth flag as required if specified by the open_api object.
However we only handle basic http authentification !!

Closes #18 

## Todo before merge:
- [x] Test It  !
 
## Todo in another PR:
Finish other issues